### PR TITLE
[DDCI-243] Allow relationships between datasets across all organisations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# ckanext-relationships
+
+This extension provides functional changes to the way relationships in CKAN work.
+
+Core CKAN restrictions for creating relationships:
+
+- Must always contain a subject package and object package
+- User must have `package_update` permission on both subject and object packages
+
+## External Relationships
+
+In some CKAN instances it may be a requirement to create relationships to external URIs.
+
+This extension enables this by allowing the `object_package_id` to be empty and
+uses the `comment` to store the external URI.
+
+## Relax package_relationship_create permissions
+
+In some CKAN instances it may be a requirement to allow users to create relationships
+from a package they DO have `package_update` permission for TO a package they DON'T
+have `package_update` permission for, i.e. creating a relationship between a package
+in an org they are an admin/editor in, to a package in another org that they are not
+and admin/editor in.
+
+### Config
+
+This extension checks for the following setting in the CKAN `.ini` file:
+
+    ckanext.relationships.package_relationship_create_ignore_auth_for
+
+This should be set to a space separated list of user roles to allow, e.g.
+
+    ckanext.relationships.package_relationship_create_ignore_auth_for = admin editor

--- a/ckanext/relationships/logic/auth/create.py
+++ b/ckanext/relationships/logic/auth/create.py
@@ -2,27 +2,84 @@ import ckan.authz as authz
 import ckan.plugins.toolkit as toolkit
 import logging
 
+from ckan.common import _, config
+
 log = logging.getLogger(__name__)
 
 
 #@toolkit.chained_auth_function
 def package_relationship_create(context, data_dict):
-    # Copied from CKAN core logic/auth/create.py
-    user = context['user']
+    # Roles allowed to create package relationships regardless
+    # of their organisation capacity for the object package
+    roles_allowed = config.get('ckanext.relationships.package_relationship_create_ignore_auth_for', None)
+
+    user_name = context.get('user', 'Unknown')
 
     id = data_dict['subject']
-    # @TODO: add check for 'object' - if it exists - call the parent auth function?
-    # id2 = data_dict['object']
 
-    # If we can update each package we can see the relationships
-    authorized1 = authz.is_authorized_boolean(
+    #
+    # @WORKAROUND: Number one
+    #
+    # CONTEXT:
+    #
+    # This auth function gets called twice:
+    # - once for the subject package in the relationship
+    # - then for the object package in the relationship
+    #
+    # data_dict['subject'] is always the ID of the package being created/updated
+    # context.get('package').id is the package being assessed for
+    #   package_update permission (could be the object package)
+    #
+    #
+    # On some CKAN instances we may want to allow authorised users to
+    # create relationships between packages where they don't have
+    # `package_update` permission on the `object` package, but it was still
+    # throwing a `NotAuthorized` exception when trying to relax that
+    # restriction and reporting that the user did not have `read` access
+    # to the subject package that they were updating (i.e. the package they
+    # DO have `package_update` permission for.
+    #
+    if roles_allowed \
+            and authz.auth_is_loggedin_user:
+        context_package = context.get('package')
+        if data_dict['subject'] == context_package.id:
+            for role in roles_allowed.split():
+                # I.E. If the user has admin/editor permission for the subject package
+                # ignore further auth checks
+                if authz.has_user_permission_for_group_or_org(context_package.owner_org, user_name, role):
+                    context['ignore_auth'] = True
+
+    #
+    # @WORKAROUND: Number two - commented out, but left for context
+    #
+    # Regardless of if the authenticated user has `package_update`
+    # permission for the package they are trying to create a relationship
+    # on it was failing to give authorisation.
+    #
+    # In this section of code, we check if they have admin or editor
+    # permission for ANY org and if so relax the restrictions by
+    # setting `context['ignore_auth'] = True`
+
+    # # 1. Is the user logged in?
+    # if roles_allowed \
+    #         and authz.auth_is_loggedin_user:
+    #     ignore_auth = False
+    #     # 2. Does the user have editor or admin capacity for any organisation?
+    #     # NOTE: Tried to use `authz.has_user_permission_for_group_or_org` here -
+    #     # but this auth function is called for each package in the relationship,
+    #     # therefore it failed on the object package if the user was not an
+    #     # admin/editor for the object package.owner_org
+    #     for role in roles_allowed.split():
+    #         if authz.has_user_permission_for_some_org(user_name, role):
+    #             ignore_auth = True
+    #     if ignore_auth:
+    #         context['ignore_auth'] = True
+
+    # Default to the normal behaviour
+    authorized = authz.is_authorized_boolean(
         'package_update', context, {'id': id})
-    # authorized2 = authz.is_authorized_boolean(
-    #     'package_update', context, {'id': id2})
 
-    # if not (authorized1 and authorized2):
-    if not authorized1:
-        # return {'success': False, 'msg': _('User %s not authorized to edit these packages') % user}
-        return {'success': False, 'msg': _('User %s not authorized to edit this package') % user}
+    if not authorized:
+        return {'success': False, 'msg': _('User %s not authorized to edit this package') % user_name}
     else:
         return {'success': True}


### PR DESCRIPTION
- Updated `logic.auth.package_relationship_create` override to allow creation of relationships from subject to object package where user does not have `package_update` permission to object package
- Added README.md